### PR TITLE
fix: load internal build numbers from eas 

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 5.4.0"
+    "version": ">= 5.4.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -10,7 +11,9 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {},
+    "production": {
+      "autoIncrement": true
+    },
     "production_apk": {
       "android": {
         "buildType": "apk"


### PR DESCRIPTION
Allows to create multiple releases in stores with the same tag (e.g. 1.4.0) as the internal build number is increased.