### PR TITLE
fix: remove wallet connection settings link

### DIFF
--- a/pages/settings/wallets/EditWallet.tsx
+++ b/pages/settings/wallets/EditWallet.tsx
@@ -49,21 +49,6 @@ export function EditWallet() {
         </Pressable>
       </Link>
       <Link
-        href={`/settings/wallets/${selectedWalletId}/wallet-connection`}
-        asChild
-      >
-        <Pressable>
-          <Card className="w-full">
-            <CardHeader>
-              <CardTitle>Wallet Connection</CardTitle>
-              <CardDescription>
-                Configure your wallet connection
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </Pressable>
-      </Link>
-      <Link
         href={`/settings/wallets/${selectedWalletId}/lightning-address`}
         asChild
       >


### PR DESCRIPTION
The wallet connection settings are currently a bit confusing for the average user, we might want to rethink what a user would want to see in there. 

We should also think about removing the option to "disconnect" a wallet (remove the connection string) maybe, it doesn't make much sense to me to separate these two entities.