### PR TITLE
fix: do not crash if NWC connection does not support notifications

### DIFF
--- a/pages/settings/wallets/WalletConnection.tsx
+++ b/pages/settings/wallets/WalletConnection.tsx
@@ -60,7 +60,7 @@ export function WalletConnection() {
       });
       const info = await nwcClient.getInfo();
       const capabilities = [...info.methods] as Nip47Capability[];
-      if (info.notifications.length) {
+      if (info.notifications?.length) {
         capabilities.push("notifications");
       }
       console.log("NWC connected", info);


### PR DESCRIPTION
Fixes https://github.com/getAlby/go/issues/78
This is why nwc.getalby.com and lifpay break with Alby Go