### PR TITLE
doc: add instructions on how to connect Alby Go with Alby Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A simple lightning mobile wallet interface that works great with [Alby Hub](https://albyhub.com)
 
+## How to connect Alby Go to your node?
+
+1. Go to your Alby Hub
+2. "Connections" -> "Add Connection"
+3. Scan the QR code or copy & paste the code
+4. Done
+
 ## Development
 
 `yarn install`


### PR DESCRIPTION
Updates `README.md` on how to connect Alby Go with your Alby Hub.

Context: when I first downloaded Alby Go from TestFlight it was not clear to me what QR code to scan.