### PR TITLE
fix: use parameter instead of state variable while setting fiat currency

### DIFF
--- a/pages/settings/FiatCurrency.tsx
+++ b/pages/settings/FiatCurrency.tsx
@@ -17,7 +17,7 @@ export function FiatCurrency() {
 
   function select(iso: string) {
     setFiatCurrency(iso);
-    useAppStore.getState().setFiatCurrency(fiatCurrency);
+    useAppStore.getState().setFiatCurrency(iso);
     Toast.show({
       type: "success",
       text1: "Fiat currency updated",


### PR DESCRIPTION
## Description

Changing fiat currency was not working for me because the state variable was not being updated, best to set it from the parameter itself