### PR TITLE
fix: onboarding state

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@ import "~/global.css";
 import { Theme, ThemeProvider } from "@react-navigation/native";
 import {
   Slot,
-  SplashScreen, useRouter
+  SplashScreen
 } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as React from "react";
@@ -16,8 +16,7 @@ import Toast from "react-native-toast-message";
 import { toastConfig } from "~/components/ToastConfig";
 import * as Font from "expo-font";
 import { useInfo } from "~/hooks/useInfo";
-import { secureStorage } from "~/lib/secureStorage";
-import { hasOnboardedKey, useAppStore } from "~/lib/state/appStore";
+import { useAppStore } from "~/lib/state/appStore";
 import { UserInactivityProvider } from "~/context/UserInactivity";
 import { PortalHost } from '@rn-primitives/portal';
 import { isBiometricSupported } from "~/lib/isBiometricSupported";
@@ -47,19 +46,8 @@ export const unstable_settings = {
 export default function RootLayout() {
   const { isDarkColorScheme } = useColorScheme();
   const [fontsLoaded, setFontsLoaded] = React.useState(false);
-  const [checkedOnboarding, setCheckedOnboarding] = React.useState(false);
-  const router = useRouter();
 
   useConnectionChecker();
-
-  async function checkOnboardingStatus() {
-    const hasOnboarded = await secureStorage.getItem(hasOnboardedKey);
-    if (!hasOnboarded) {
-      router.replace("/onboarding");
-    }
-
-    setCheckedOnboarding(true);
-  };
 
   async function loadFonts() {
     await Font.loadAsync({
@@ -83,7 +71,6 @@ export default function RootLayout() {
     const init = async () => {
       try {
         await Promise.all([
-          checkOnboardingStatus(),
           loadFonts(),
           checkBiometricStatus(),
         ]);
@@ -96,7 +83,7 @@ export default function RootLayout() {
     init();
   }, []);
 
-  if (!fontsLoaded || !checkedOnboarding) {
+  if (!fontsLoaded) {
     return null;
   }
 

--- a/pages/Onboarding.tsx
+++ b/pages/Onboarding.tsx
@@ -24,7 +24,7 @@ export function Onboarding() {
       <View className="flex-1 flex items-center justify-center gap-4">
         <Image
           source={require('./../assets/logo.png')}
-          className="mb-10 w-52 h-52 object-contain"
+          className="mb-10 w-52 h-52" resizeMode="contain"
         />
         <Text className="font-semibold2 text-4xl text-center text-foreground">Hello there 👋</Text>
         <Text className="font-medium2 text-xl text-muted-foreground text-center">

--- a/pages/Unlock.tsx
+++ b/pages/Unlock.tsx
@@ -44,7 +44,8 @@ export function Unlock() {
       <View className="flex-1 flex items-center justify-center gap-4">
         <Image
           source={require('./../assets/logo.png')}
-          className="mb-10 w-52 h-52 object-contain"
+          className="mb-10 w-52 h-52"
+          resizeMode="contain"
         />
         <Text className="font-semibold2 text-4xl text-center text-foreground">Unlock to continue</Text>
       </View>


### PR DESCRIPTION
Move onboarding check to inner layout to prevent any route updates before the rootNavigationState is available. 

Prevents "white screen of ☠️" for new users. :see_no_evil: 