### PR TITLE
fix: remove get_info from required capabilities

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -29,4 +29,9 @@ export const DEFAULT_CURRENCY = "USD";
 export const DEFAULT_WALLET_NAME = "Default Wallet";
 export const ALBY_LIGHTNING_ADDRESS = "go@getalby.com";
 
-export const REQUIRED_CAPABILITIES: Nip47Capability[] = ["get_info", "get_balance", "make_invoice", "pay_invoice", "list_transactions"];
+export const REQUIRED_CAPABILITIES: Nip47Capability[] = [
+  "get_balance",
+  "make_invoice",
+  "pay_invoice",
+  "list_transactions",
+];


### PR DESCRIPTION
Removes `get_info` from the required capabilities, since `get_info` should always be available. 