### PR TITLE
fix: make status bar translucent

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -83,7 +83,7 @@ export default function RootLayout() {
   return (
     <SWRConfig value={swrConfiguration}>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
-        <StatusBar style={isDarkColorScheme ? "light" : "dark"} />
+        <StatusBar translucent style={isDarkColorScheme ? "light" : "dark"} />
         <PolyfillCrypto />
         <SafeAreaView className="w-full h-full bg-background">
           <UserInactivityProvider>


### PR DESCRIPTION
> Is it possible to make top and bottom iOS UI blend with Go bg color? 

![image](https://github.com/user-attachments/assets/dfbd4905-40f6-4a79-9514-56c261b0bb1b)

Needs some testing on iOS, didn't change anything on Android it seems.