### PR TITLE
chore: specify lsminimumsystemversion to avoid app store warnings

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,6 +46,9 @@
       "bundleIdentifier": "com.getalby.mobile",
       "config": {
         "usesNonExemptEncryption": false
+      },
+      "infoPlist": {
+        "LSMinimumSystemVersion": "12.0"
       }
     },
     "android": {


### PR DESCRIPTION
Fixes #181 