### PR TITLE
fix: check for ln address and bolt11 before navigating to send

### DIFF
--- a/hooks/__tests__/useHandleLinking.ts
+++ b/hooks/__tests__/useHandleLinking.ts
@@ -33,38 +33,51 @@ jest.mock("../../lib/lnurl", () => {
 const testVectors: Record<string, { url: string; path: string }> = {
   // Lightning Addresses
   "lightning:hello@getalby.com": {
-    url: "lightning:hello@getalby.com",
+    url: "hello@getalby.com",
     path: "/send",
   },
   "lightning://hello@getalby.com": {
-    url: "lightning:hello@getalby.com",
+    url: "hello@getalby.com",
     path: "/send",
   },
   "LIGHTNING://hello@getalby.com": {
-    url: "lightning:hello@getalby.com",
+    url: "hello@getalby.com",
     path: "/send",
   },
   "LIGHTNING:hello@getalby.com": {
-    url: "lightning:hello@getalby.com",
+    url: "hello@getalby.com",
     path: "/send",
   },
 
   // Lightning invoices
-  "lightning:lnbc1": { url: "lightning:lnbc1", path: "/send" },
-  "lightning://lnbc1": { url: "lightning:lnbc1", path: "/send" },
-
-  // BIP21
-  "bitcoin:bitcoinaddress?lightning=invoice": {
-    url: "bitcoin:bitcoinaddress?lightning=invoice",
+  "lightning:lnbc123": {
+    url: "lnbc123",
     path: "/send",
   },
-  "BITCOIN:bitcoinaddress?lightning=invoice": {
-    url: "bitcoin:bitcoinaddress?lightning=invoice",
+  "lightning://lnbc123": {
+    url: "lnbc123",
+    path: "/send",
+  },
+
+  // BIP21
+  "bitcoin:bitcoinaddress?lightning=lnbc123": {
+    url: "lnbc123",
+    path: "/send",
+  },
+  "BITCOIN:bitcoinaddress?lightning=lnbc123": {
+    url: "lnbc123",
     path: "/send",
   },
 
   // LNURL-withdraw
-  "lightning:lnurlw123": { url: "lightning:lnurlw123", path: "/withdraw" },
+  "lightning:lnurlw123": {
+    url: "lnurlw123",
+    path: "/withdraw",
+  },
+  "lightning://lnurlw123": {
+    url: "lnurlw123",
+    path: "/withdraw",
+  },
 };
 
 describe("handleLink", () => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -40,3 +40,5 @@ export const REQUIRED_CAPABILITIES: Nip47Capability[] = [
 export const SATS_REGEX = /^\d*$/;
 
 export const FIAT_REGEX = /^\d*(\.\d{0,2})?$/;
+
+export const BOLT11_REGEX = /.*?((lnbcrt|lntb|lnbc)([0-9]{1,}[a-z0-9]+){1})/;


### PR DESCRIPTION
Fixes #162 and also an issue where scanning `alby:hello@getalby.com` QRs result in `Failed to decoide payment request errors`