### PR TITLE
chore: set preferred scheme to lightning

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Alby Go",
     "slug": "alby-mobile",
     "version": "1.7.1",
-    "scheme": ["bitcoin", "lightning", "alby"],
+    "scheme": ["lightning", "bitcoin", "alby"],
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Expo linking prefers the first value in the schemes array. Given we offer more support for `lightning:` links than `bitcoin:` it's good to have `lightning:` as preferred