### PR TITLE
fix: prevent state updates in parent while rendering qrcodescanner

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -41,14 +41,11 @@ function QRCodeScanner({
   }
 
   const handleScanned = (data: string) => {
-    setScanning((current) => {
-      if (current === true) {
-        console.info(`Bar code with data ${data} has been scanned!`);
-        onScanned(data);
-        return true;
-      }
-      return false;
-    });
+    if (isScanning) {
+      console.info(`Bar code with data ${data} has been scanned!`);
+      onScanned(data);
+      setScanning(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

### Issue

This is logged when a QR is scanned:
`Warning: Cannot update a component (SetupWallet) while rendering a different component (QRCodeScanner). To locate the bad setState() call inside QRCodeScanner, follow the stack trace as described in https://reactjs.org/link/setstate-in-render`

### The fix

Updater functions run during rendering, and that causes state updates in the parent as we are calling `onScanned`, so this moves that out to check `isScanning` and then proceed so that the logic is same but it is just moved outside the updater function