### PR TITLE
fix: use expo recommended safearea

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -95,7 +95,7 @@ export default function RootLayout() {
     <SWRConfig value={swrConfiguration}>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
         <StatusBar style={isDarkColorScheme ? "light" : "dark"} />
-        <SafeAreaView className="w-full h-full">
+        <SafeAreaView className="w-full h-full bg-background">
           <UserInactivityProvider>
             <SessionProvider>
               <Slot />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,7 +10,7 @@ import { Slot, SplashScreen } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { swrConfiguration } from "lib/swr";
 import * as React from "react";
-import { SafeAreaView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { SWRConfig } from "swr";
 import { toastConfig } from "~/components/ToastConfig";
@@ -95,7 +95,7 @@ export default function RootLayout() {
     <SWRConfig value={swrConfiguration}>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
         <StatusBar style={isDarkColorScheme ? "light" : "dark"} />
-        <SafeAreaView className="w-full h-full bg-background">
+        <SafeAreaView className="w-full h-full">
           <UserInactivityProvider>
             <SessionProvider>
               <Slot />

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-get-random-values": "^1.9.0",
     "react-native-qrcode-svg": "^6.3.1",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.12.0",
+    "react-native-safe-area-context": "5.0.0",
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-toast-message": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7903,10 +7903,10 @@ react-native-reanimated@~3.16.1:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz#17868522a55bbc6757418c94a1b4abdda6b045d9"
-  integrity sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==
+react-native-safe-area-context@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.0.0.tgz#0f28f3b406d4466c6afdaaa615198d12741e88b5"
+  integrity sha512-4K4TvEbRsTDYuSSJZfMNKuJNn1+qgrSkOBwRoreiHcuqy1egrHpkhPhoN1Zg1+b3BxcVXlKXtMIf4eVaG/DPJw==
 
 react-native-screens@~4.1.0:
   version "4.1.0"


### PR DESCRIPTION
During development, often the Stack.Screen goes down, interfering with the view. I found that the SafeArea we are using is from react-native, but expo has it's own safe area: https://docs.expo.dev/versions/latest/sdk/safe-area-context/ and replacing with that fixes the issue.

<table><tr><td>
<img src="https://github.com/user-attachments/assets/c885be6d-7939-49b2-a0e0-46ac050136ea"/></td><td>
<img src="https://github.com/user-attachments/assets/f2c508db-07f1-4e2c-afae-fa17bcb5be94"/></td></tr></table>