### PR TITLE
chore: dismiss all before returning home

### DIFF
--- a/pages/settings/wallets/SetupWallet.tsx
+++ b/pages/settings/wallets/SetupWallet.tsx
@@ -134,7 +134,6 @@ export function SetupWallet() {
     if (router.canDismiss()) {
       router.dismissAll();
     }
-    router.navigate("/");
   };
 
   React.useEffect(() => {
@@ -167,7 +166,6 @@ export function SetupWallet() {
                 if (router.canDismiss()) {
                   router.dismissAll();
                 }
-                router.navigate("/");
               }}
             >
               <X className="text-foreground" />

--- a/pages/settings/wallets/SetupWallet.tsx
+++ b/pages/settings/wallets/SetupWallet.tsx
@@ -119,7 +119,10 @@ export function SetupWallet() {
       position: "top",
     });
 
-    router.replace("/");
+    if (router.canDismiss()) {
+      router.dismissAll();
+    }
+    router.navigate("/");
   };
 
   return (
@@ -133,7 +136,10 @@ export function SetupWallet() {
                 useAppStore
                   .getState()
                   .setSelectedWalletId(walletIdWithConnection);
-                router.replace("/");
+                if (router.canDismiss()) {
+                  router.dismissAll();
+                }
+                router.navigate("/");
               }}
             >
               <X className="text-foreground" />


### PR DESCRIPTION
This removes the back button in the header, if you cancel/finish setup

Note: for some reason, this cannot be observed in Expo Go but the production build also has this issue.

## Screenshots

<table><tr><td>
<img src="https://github.com/user-attachments/assets/2590f3f4-3774-4ac0-be69-2dbd3424779c"/>
</td><td>
<img src="https://github.com/user-attachments/assets/87ccb30e-9b9e-4cf4-b395-9adbb48fbd71"/>
</td></tr></table>
