### PR TITLE
fix: qr scanner on failure

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 });
 
 interface QRCodeScannerProps {
-  onScanned: (data: string) => void;
+  onScanned: (data: string) => Promise<boolean>;
   startScanning: boolean;
 }
 
@@ -49,11 +49,11 @@ function QRCodeScanner({
     setScanning(status === "granted");
   }
 
-  const handleScanned = (data: string) => {
+  const handleScanned = async (data: string) => {
     if (isScanning) {
       console.info(`Bar code with data ${data} has been scanned!`);
-      onScanned(data);
-      setScanning(false);
+      const result = await onScanned(data);
+      setScanning(!result);
     }
   };
 


### PR DESCRIPTION
## Description

#196 fixed the `Cannot update a component` warning but introduced a big error where the scanner would stop scanning if a faulty qr is scanned instead oif showing an error and proceeding to scan further. This PR aims to resolve this

