### PR TITLE
fix: screen header buttons

### DIFF
--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -147,12 +147,14 @@ export function Home() {
           </View>
         </ScrollView>
         <View className="flex items-center justify-center">
-          <Link href="/transactions">
-            <ChevronUpIcon
-              className="text-muted-foreground"
-              width={32}
-              height={32}
-            />
+          <Link href="/transactions" asChild>
+            <TouchableOpacity>
+              <ChevronUpIcon
+                className="text-muted-foreground"
+                width={32}
+                height={32}
+              />
+            </TouchableOpacity>
           </Link>
         </View>
         <View className="flex flex-row gap-6 mt-10">

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -65,11 +65,13 @@ export function Home() {
       <Screen
         title=""
         right={() => (
-          <Link href="/settings" asChild>
-            <TouchableOpacity>
-              <SettingsIcon className="text-muted-foreground" />
-            </TouchableOpacity>
-          </Link>
+          <TouchableOpacity
+            onPressIn={() => {
+              router.push("/settings");
+            }}
+          >
+            <SettingsIcon className="text-muted-foreground" />
+          </TouchableOpacity>
         )}
       />
       <View className="h-full flex p-6">

--- a/pages/Transactions.tsx
+++ b/pages/Transactions.tsx
@@ -75,7 +75,7 @@ export function Transactions() {
         animation="slide_from_bottom"
         right={() => (
           <Pressable
-            onPress={() => {
+            onPressIn={() => {
               router.back();
             }}
           >

--- a/pages/send/PaymentSuccess.tsx
+++ b/pages/send/PaymentSuccess.tsx
@@ -1,6 +1,7 @@
 import { openURL } from "expo-linking";
 import { router, useLocalSearchParams } from "expo-router";
 import { LNURLPaymentSuccessAction } from "lib/lnurl";
+import React from "react";
 import { ScrollView, View } from "react-native";
 import { Tick } from "~/animations/Tick";
 import { Receiver } from "~/components/Receiver";

--- a/pages/settings/wallets/SetupWallet.tsx
+++ b/pages/settings/wallets/SetupWallet.tsx
@@ -4,7 +4,7 @@ import * as Clipboard from "expo-clipboard";
 import { router, useLocalSearchParams } from "expo-router";
 import { useAppStore } from "lib/state/appStore";
 import React from "react";
-import { Pressable, TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 import Toast from "react-native-toast-message";
 import Alert from "~/components/Alert";
 import DismissableKeyboardView from "~/components/DismissableKeyboardView";
@@ -153,8 +153,8 @@ export function SetupWallet() {
         title="Setup Wallet Connection"
         right={() =>
           walletIdWithConnection !== -1 ? (
-            <Pressable
-              onPress={() => {
+            <TouchableOpacity
+              onPressIn={() => {
                 useAppStore
                   .getState()
                   .setSelectedWalletId(walletIdWithConnection);
@@ -165,7 +165,7 @@ export function SetupWallet() {
               }}
             >
               <XIcon className="text-foreground" />
-            </Pressable>
+            </TouchableOpacity>
           ) : (
             <Dialog>
               <DialogTrigger asChild>


### PR DESCRIPTION
Fixes screen header's right buttons not working due to issue in expo-router: https://github.com/expo/expo/issues/29489

Changes `onPress` to `onPressIn`