### PR TITLE
feat: add extra metadata for payments (POC)

### DIFF
--- a/pages/Transaction.tsx
+++ b/pages/Transaction.tsx
@@ -66,6 +66,7 @@ export function Transaction() {
     | {
         payer_data?: { name?: string };
         recipient_data?: { identifier?: string; description?: string };
+        comment?: string;
       }
     | undefined;
 
@@ -166,6 +167,12 @@ export function Transaction() {
                 "-"
               }
             />
+            {metadata?.comment && (
+              <TransactionDetailRow
+                title="Comment"
+                content={metadata.comment}
+              />
+            )}
 
             {boostagram && <PodcastingInfo boost={boostagram} />}
 

--- a/pages/Transaction.tsx
+++ b/pages/Transaction.tsx
@@ -60,6 +60,15 @@ export function Transaction() {
     return parsedBoostagram;
   }, [transaction.metadata]);
 
+  // TODO: extract typings
+  // TODO: review "description" field
+  const metadata = transaction.metadata as
+    | {
+        payer_data?: { name?: string };
+        recipient_data?: { identifier?: string; description?: string };
+      }
+    | undefined;
+
   return (
     <View className="flex-1 flex flex-col gap-3">
       <Screen title="Transaction" />
@@ -130,6 +139,18 @@ export function Transaction() {
             )}
           </View>
           <View className="flex flex-col gap-4 w-full mt-10">
+            {metadata?.recipient_data?.identifier && (
+              <TransactionDetailRow
+                title="To"
+                content={metadata.recipient_data.identifier}
+              />
+            )}
+            {metadata?.payer_data?.name && (
+              <TransactionDetailRow
+                title="From"
+                content={metadata.payer_data.name}
+              />
+            )}
             <TransactionDetailRow
               title="Date & Time"
               content={dayjs
@@ -138,7 +159,12 @@ export function Transaction() {
             />
             <TransactionDetailRow
               title="Description"
-              content={transaction.description || "-"}
+              content={
+                // TODO: should this description be merged on Alby Hub side?
+                transaction.description ||
+                metadata?.recipient_data?.description ||
+                "-"
+              }
             />
 
             {boostagram && <PodcastingInfo boost={boostagram} />}
@@ -167,6 +193,13 @@ export function Transaction() {
               <TransactionDetailRow
                 title="Preimage"
                 content={transaction.preimage}
+                copy
+              />
+            )}
+            {transaction.metadata && (
+              <TransactionDetailRow
+                title="Metadata"
+                content={JSON.stringify(transaction.metadata, null, 2)}
                 copy
               />
             )}

--- a/pages/Transactions.tsx
+++ b/pages/Transactions.tsx
@@ -110,83 +110,107 @@ export function Transactions() {
               setPage(page + 1);
             }
           }}
-          renderItem={({ item: transaction }) => (
-            <Pressable
-              key={transaction.payment_hash}
-              onPress={() =>
-                router.navigate({
-                  pathname: "/transaction",
-                  params: { transactionJSON: JSON.stringify(transaction) },
-                })
-              }
-            >
-              <View
-                className={cn(
-                  "flex flex-row items-center gap-3 px-6 py-2 my-2",
-                  transaction.state === "pending" && "animate-pulse",
-                )}
+          renderItem={({ item: transaction }) => {
+            // TODO: extract typings
+            // TODO: review "description" field
+            const metadata = transaction.metadata as
+              | {
+                  recipient_data?: {
+                    identifier?: string;
+                    description?: string;
+                  };
+                }
+              | undefined;
+
+            return (
+              <Pressable
+                key={transaction.payment_hash}
+                onPress={() =>
+                  router.navigate({
+                    pathname: "/transaction",
+                    params: { transactionJSON: JSON.stringify(transaction) },
+                  })
+                }
               >
-                <View className="w-10 h-10 bg-muted rounded-full flex flex-col items-center justify-center">
-                  {!(
-                    transaction.state === "failed" ||
-                    transaction.state === "pending"
-                  ) && (
-                    <>
-                      {transaction.type === "incoming" && (
-                        <ReceivedTransactionIcon />
-                      )}
-                      {transaction.type === "outgoing" && (
-                        <SentTransactionIcon />
-                      )}
-                    </>
+                <View
+                  className={cn(
+                    "flex flex-row items-center gap-3 px-6 py-2 my-2",
+                    transaction.state === "pending" && "animate-pulse",
                   )}
-                  {transaction.state === "pending" && (
-                    <PendingTransactionIcon />
-                  )}
-                  {transaction.state === "failed" && <FailedTransactionIcon />}
-                </View>
-                <View className="flex flex-col flex-1">
-                  <View className="flex flex-row flex-1 items-center gap-2">
-                    <Text numberOfLines={1} className="font-medium2 text-lg">
-                      {transaction.type === "incoming"
-                        ? "Received"
-                        : transaction.state === "failed"
-                          ? "Failed"
-                          : transaction.state === "pending"
-                            ? "Sending"
-                            : "Sent"}
+                >
+                  <View className="w-10 h-10 bg-muted rounded-full flex flex-col items-center justify-center">
+                    {!(
+                      transaction.state === "failed" ||
+                      transaction.state === "pending"
+                    ) && (
+                      <>
+                        {transaction.type === "incoming" && (
+                          <ReceivedTransactionIcon />
+                        )}
+                        {transaction.type === "outgoing" && (
+                          <SentTransactionIcon />
+                        )}
+                      </>
+                    )}
+                    {transaction.state === "pending" && (
+                      <PendingTransactionIcon />
+                    )}
+                    {transaction.state === "failed" && (
+                      <FailedTransactionIcon />
+                    )}
+                  </View>
+                  <View className="flex flex-col flex-1">
+                    <View className="flex flex-row flex-1 items-center gap-2">
+                      <Text numberOfLines={1} className="font-medium2 text-lg">
+                        {transaction.type === "incoming"
+                          ? "Received"
+                          : transaction.state === "failed"
+                            ? "Failed"
+                            : transaction.state === "pending"
+                              ? "Sending"
+                              : "Sent"}
+                      </Text>
+                      <Text className="text-muted-foreground text-sm">
+                        {dayjs
+                          .unix(
+                            transaction.settled_at || transaction.created_at,
+                          )
+                          .fromNow()}
+                      </Text>
+                    </View>
+                    {(transaction.description ||
+                      metadata?.recipient_data?.description) && (
+                      <Text numberOfLines={1}>
+                        {transaction.description ||
+                          metadata?.recipient_data?.description}
+                      </Text>
+                    )}
+                  </View>
+                  <View>
+                    <Text
+                      className={cn(
+                        "text-right font-medium2 text-lg",
+                        transaction.type === "incoming"
+                          ? "text-receive"
+                          : "text-foreground",
+                      )}
+                    >
+                      {transaction.type === "incoming" ? "+" : "-"}{" "}
+                      {Math.floor(transaction.amount / 1000)}
+                      <Text className="text-muted-foreground text-lg">
+                        {" "}
+                        sats
+                      </Text>
                     </Text>
-                    <Text className="text-muted-foreground text-sm">
-                      {dayjs
-                        .unix(transaction.settled_at || transaction.created_at)
-                        .fromNow()}
+                    <Text className="text-right text-sm text-muted-foreground font-medium2">
+                      {getFiatAmount &&
+                        getFiatAmount(Math.floor(transaction.amount / 1000))}
                     </Text>
                   </View>
-                  {transaction.description && (
-                    <Text numberOfLines={1}>{transaction.description}</Text>
-                  )}
                 </View>
-                <View>
-                  <Text
-                    className={cn(
-                      "text-right font-medium2 text-lg",
-                      transaction.type === "incoming"
-                        ? "text-receive"
-                        : "text-foreground",
-                    )}
-                  >
-                    {transaction.type === "incoming" ? "+" : "-"}{" "}
-                    {Math.floor(transaction.amount / 1000)}
-                    <Text className="text-muted-foreground text-lg"> sats</Text>
-                  </Text>
-                  <Text className="text-right text-sm text-muted-foreground font-medium2">
-                    {getFiatAmount &&
-                      getFiatAmount(Math.floor(transaction.amount / 1000))}
-                  </Text>
-                </View>
-              </View>
-            </Pressable>
-          )}
+              </Pressable>
+            );
+          }}
         />
       ) : !transactionsLoaded ? (
         <ScrollView className="mt-3">

--- a/pages/send/ConfirmPayment.tsx
+++ b/pages/send/ConfirmPayment.tsx
@@ -59,6 +59,7 @@ export function ConfirmPayment() {
             identifier: recipientIdentifier,
             description: recipientDescription,
           },
+          comment,
         },
       });
 

--- a/pages/send/ConfirmPayment.tsx
+++ b/pages/send/ConfirmPayment.tsx
@@ -18,14 +18,23 @@ import { useAppStore } from "~/lib/state/appStore";
 
 export function ConfirmPayment() {
   const { data: transactions } = useTransactions();
-  const { invoice, originalText, comment, successAction, amount } =
-    useLocalSearchParams() as {
-      invoice: string;
-      originalText: string;
-      comment: string;
-      successAction: string;
-      amount?: string;
-    };
+  const {
+    invoice,
+    originalText,
+    comment,
+    successAction,
+    amount,
+    recipientDescription,
+    recipientIdentifier,
+  } = useLocalSearchParams() as {
+    invoice: string;
+    originalText: string;
+    comment: string;
+    successAction: string;
+    amount?: string;
+    recipientDescription?: string;
+    recipientIdentifier?: string;
+  };
   const getFiatAmount = useGetFiatAmount();
   const [isLoading, setLoading] = React.useState(false);
   const wallets = useAppStore((store) => store.wallets);
@@ -45,6 +54,12 @@ export function ConfirmPayment() {
       const response = await nwcClient.payInvoice({
         invoice,
         amount: amount ? amountToPaySats * 1000 : undefined,
+        metadata: {
+          recipient_data: {
+            identifier: recipientIdentifier,
+            description: recipientDescription,
+          },
+        },
       });
 
       console.info("payInvoice Response", response);

--- a/pages/send/LNURLPay.tsx
+++ b/pages/send/LNURLPay.tsx
@@ -52,6 +52,24 @@ export function LNURLPay() {
       if (comment) {
         callback.searchParams.append("comment", comment);
       }
+      let recipientDescription = "";
+      try {
+        recipientDescription =
+          (
+            JSON.parse(decodeURIComponent(lnurlDetails.metadata)) as string[][]
+          ).find((t) => t[0] === "text/plain")?.[1] || "";
+      } catch (error) {
+        console.error("failed to parse recipient description", error);
+      }
+      let recipientIdentifier = "";
+      try {
+        recipientIdentifier =
+          (
+            JSON.parse(decodeURIComponent(lnurlDetails.metadata)) as string[][]
+          ).find((t) => t[0] === "text/identifier")?.[1] || "";
+      } catch (error) {
+        console.error("failed to parse recipient identifier", error);
+      }
       //callback.searchParams.append("payerdata", JSON.stringify({ test: 1 }));
       const lnurlPayInfo = await lnurl.getPayRequest(callback.toString());
       //console.log("Got pay request", lnurlPayInfo.pr);
@@ -60,6 +78,8 @@ export function LNURLPay() {
         params: {
           invoice: lnurlPayInfo.pr,
           originalText,
+          recipientDescription,
+          recipientIdentifier,
           comment,
           successAction: lnurlPayInfo.successAction
             ? JSON.stringify(lnurlPayInfo.successAction)


### PR DESCRIPTION
This adds much more context to the transaction list than was there before (normally you pay to a lightning address and afterwards see an empty transaction)

Needs planning on how the data should be structured, there are some new concepts here. I am just showing what is possible with being able to set metadata when paying. This PR also includes showing a lud-18 payer name for received payments.

![image](https://github.com/user-attachments/assets/a7bae091-2ce6-4e8c-b351-770026ad5c38)

![image](https://github.com/user-attachments/assets/878f07aa-b913-4aaa-a76d-fbb22512020a)

![image](https://github.com/user-attachments/assets/2c6b78d4-aeca-455a-8c38-3cd12253e941)

