### PR TITLE
Expose MakeInvoice and LookupInvoice as iOS AppIntents

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,47 @@
         }
       ],
       [
+        "expo-ios-app-intents",
+        {
+          "intents": [
+            {
+              "name": "MakeInvoice",
+              "title": "Create Lightning Invoice",
+              "description": "Generate a new lightning network invoice",
+              "resultType": "String",
+              "parameters": [
+                {
+                  "name": "Amount",
+                  "type": "Int",
+                  "description": "Amount in satoshis",
+                  "required": true
+                },
+                {
+                  "name": "Description",
+                  "type": "String",
+                  "description": "Invoice description",
+                  "required": false
+                }
+              ]
+            },
+            {
+              "name": "LookupInvoice",
+              "title": "Lookup Lightning Invoice",
+              "description": "Look up the status of a lightning network invoice",
+              "resultType": "String",
+              "parameters": [
+                {
+                  "name": "Invoice",
+                  "type": "String",
+                  "description": "The invoice",
+                  "required": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
         "expo-camera",
         {
           "cameraPermission": "Allow Alby Go to use the camera to scan wallet connection and payment QR codes",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import { swrConfiguration } from "lib/swr";
 import * as React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
+import { setupLightningIntentHandlers } from "~/lib/appIntents/LightningIntents";
 import { SWRConfig } from "swr";
 import { toastConfig } from "~/components/ToastConfig";
 import { UserInactivityProvider } from "~/context/UserInactivity";
@@ -82,6 +83,7 @@ export default function RootLayout() {
   React.useEffect(() => {
     const init = async () => {
       try {
+        setupLightningIntentHandlers();
         await Promise.all([loadTheme(), loadFonts(), checkBiometricStatus()]);
       } finally {
         setResourcesLoaded(true);

--- a/lib/appIntents/LightningIntents.ts
+++ b/lib/appIntents/LightningIntents.ts
@@ -1,0 +1,62 @@
+import ExpoAppIntents from "expo-ios-app-intents";
+import { useAppStore } from "../state/appStore";
+import { Nip47Transaction } from "@getalby/sdk/dist/NWCClient";
+
+export interface MakeInvoiceParameters {
+  _Amount: number;
+  _Description?: string;
+}
+
+export interface LookupInvoiceParameters {
+  _Invoice: string;
+}
+
+// Define the proper IntentEventPayload type
+interface IntentEventPayload {
+  id: string;
+  name: string;
+  parameters: Record<string, any>;
+}
+
+async function handleIntent(event: IntentEventPayload) {
+  const { name, parameters, id } = event;
+  const nwcClient = useAppStore.getState().nwcClient;
+
+  if (!nwcClient) {
+    ExpoAppIntents.failIntent(id, "NWC client not connected");
+    return;
+  }
+
+  try {
+    if (name === "MakeInvoice") {
+      const { _Amount, _Description } = parameters as MakeInvoiceParameters;
+      const response = (await nwcClient.makeInvoice({
+        amount: _Amount,
+        ...(_Description ? { description: _Description } : {}),
+      })) as Nip47Transaction;
+      // Return [invoice, paymentHash] as string array
+      ExpoAppIntents.completeIntent(id, { value: JSON.stringify(response) });
+    } else if (name === "LookupInvoice") {
+      const { _Invoice } = parameters as LookupInvoiceParameters;
+      const response = (await nwcClient.lookupInvoice({
+        invoice: _Invoice,
+      })) as Nip47Transaction;
+
+      // Return [paid, preimage, amount, description] as string array
+      // Determine paid status from presence of settled_at timestamp
+      ExpoAppIntents.completeIntent(id, { value: JSON.stringify(response) });
+    }
+  } catch (error) {
+    console.error("App Intent error:", error);
+    ExpoAppIntents.failIntent(
+      id,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+export const setupLightningIntentHandlers = () => {
+  ExpoAppIntents.addListener("onIntent", (event: IntentEventPayload) => {
+    handleIntent(event);
+  });
+};

--- a/lib/appIntents/types.ts
+++ b/lib/appIntents/types.ts
@@ -1,0 +1,16 @@
+export interface MakeInvoiceResponse {
+  invoice: string;
+  paymentHash: string;
+}
+
+export interface LookupInvoiceResponse {
+  paid: boolean;
+  preimage?: string;
+  amount: number;
+  description?: string;
+}
+
+export interface NWCInvoiceError {
+  error: string;
+  message: string;
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-linear-gradient": "~14.0.1",
     "expo-linking": "~7.0.3",
     "expo-local-authentication": "~15.0.1",
+    "expo-ios-app-intents": "ynniv/expo-ios-app-intents",
     "expo-router": "~4.0.15",
     "expo-secure-store": "~14.0.0",
     "expo-splash-screen": "^0.29.18",


### PR DESCRIPTION
Apple's AppIntents framework lets you expose actions to the Shortcuts app, which is more powerful than regular apps. By exposing MakeInvoice and LookupInvoice, you can write a shortcut that takes a screenshot, converts it to text, finds a dollar amount, makes an invoice, displays it as a QR code, and then polls for payment.

Demo: https://primal.net/e/note1d9kjv2wl7tp4zt0ntz73ycfk8s674jm7ttax9fydtlcqw8nwzf3qu8802y

I had to make a new Expo plugin for this, so also see https://github.com/ynniv/expo-ios-app-intents
