### PR TITLE
chore: check wallet id before throwing error

### DIFF
--- a/hooks/useBalance.ts
+++ b/hooks/useBalance.ts
@@ -5,15 +5,22 @@ import { errorToast } from "~/lib/errorToast";
 type FetchArgs = Parameters<typeof fetch>;
 const fetcher = async (...args: FetchArgs) => {
   const nwcClient = useAppStore.getState().nwcClient;
+  const currentWalletId = useAppStore.getState().selectedWalletId;
   if (!nwcClient) {
     throw new Error("No NWC client");
   }
   try {
     const balance = await nwcClient.getBalance();
+    if (currentWalletId !== useAppStore.getState().selectedWalletId) {
+      return;
+    }
     return balance;
   } catch (error) {
-    errorToast(error);
-    throw error;
+    console.error(error);
+    if (currentWalletId === useAppStore.getState().selectedWalletId) {
+      errorToast(error);
+      throw error;
+    }
   }
 };
 

--- a/hooks/useInfo.ts
+++ b/hooks/useInfo.ts
@@ -5,19 +5,30 @@ import { errorToast } from "~/lib/errorToast";
 type FetchArgs = Parameters<typeof fetch>;
 const fetcher = async (...args: FetchArgs) => {
   const nwcClient = useAppStore.getState().nwcClient;
+  const currentWalletId = useAppStore.getState().selectedWalletId;
   if (!nwcClient) {
     throw new Error("No NWC client");
   }
   try {
     const info = await nwcClient.getInfo();
+    if (currentWalletId !== useAppStore.getState().selectedWalletId) {
+      return;
+    }
     return info;
-  } catch (error) {
-    errorToast(error);
-    throw error;
+  } catch (error: unknown) {
+    console.error(error);
+    if (currentWalletId === useAppStore.getState().selectedWalletId) {
+      errorToast(error);
+      throw error;
+    }
   }
 };
 
 export function useInfo() {
   const nwcClient = useAppStore((store) => store.nwcClient);
-  return useSWR(nwcClient && "getInfo", fetcher);
+  const selectedWalletId = useAppStore((store) => store.selectedWalletId);
+  return useSWR(
+    nwcClient && `getInfo?selectedWalletId=${selectedWalletId}`,
+    fetcher,
+  );
 }

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -7,6 +7,7 @@ type FetchArgs = Parameters<typeof fetch>;
 
 const fetcher = async (...args: FetchArgs) => {
   const nwcClient = useAppStore.getState().nwcClient;
+  const currentWalletId = useAppStore.getState().selectedWalletId;
   if (!nwcClient) {
     throw new Error("No NWC client");
   }
@@ -20,10 +21,16 @@ const fetcher = async (...args: FetchArgs) => {
       offset: (page - 1) * TRANSACTIONS_PAGE_SIZE,
       unpaid_outgoing: true,
     });
+    if (currentWalletId !== useAppStore.getState().selectedWalletId) {
+      return;
+    }
     return transactions;
   } catch (error) {
-    errorToast(error);
-    throw error;
+    console.error(error);
+    if (currentWalletId === useAppStore.getState().selectedWalletId) {
+      errorToast(error);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #252

Checks if the previously invoked fetcher belongs to the current selected wallet id so that we don't display errors belonging to other wallets.
