### PR TITLE
Fix: Wrap error title

### DIFF
--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -39,9 +39,7 @@ function Alert({ title, description, type, icon: Icon, className }: Props) {
       <CardContent className="flex flex-row items-center gap-4">
         <Icon className={textColor} width={24} height={24} />
         <View className="flex flex-1 flex-col">
-          <CardTitle className={textColor} wrapText>
-            {title}
-          </CardTitle>
+          <CardTitle className={textColor}>{title}</CardTitle>
           <CardDescription className={textColor}>{description}</CardDescription>
         </View>
       </CardContent>

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -39,7 +39,9 @@ function Alert({ title, description, type, icon: Icon, className }: Props) {
       <CardContent className="flex flex-row items-center gap-4">
         <Icon className={textColor} width={24} height={24} />
         <View className="flex flex-1 flex-col">
-          <CardTitle className={textColor}>{title}</CardTitle>
+          <CardTitle className={textColor} wrapText>
+            {title}
+          </CardTitle>
           <CardDescription className={textColor}>{description}</CardDescription>
         </View>
       </CardContent>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -33,13 +33,13 @@ CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof Text> & { wrapText?: boolean }
+>(({ className, wrapText = false, ...props }, ref) => (
   <Text
     role="heading"
     aria-level={3}
     ref={ref}
-    numberOfLines={1}
+    numberOfLines={wrapText ? undefined : 1}
     ellipsizeMode="tail"
     className={cn(
       "text-xl text-card-foreground font-semibold2 leading-none tracking-tight",

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -33,13 +33,12 @@ CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   TextRef,
-  React.ComponentPropsWithoutRef<typeof Text> & { wrapText?: boolean }
->(({ className, wrapText = false, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof Text>
+>(({ className, ...props }, ref) => (
   <Text
     role="heading"
     aria-level={3}
     ref={ref}
-    numberOfLines={wrapText ? undefined : 1}
     ellipsizeMode="tail"
     className={cn(
       "text-xl text-card-foreground font-semibold2 leading-none tracking-tight",


### PR DESCRIPTION
Fixes #251 

Add a boolean wrapText prop to CardTitle component that when set allows the text to wrap.

This pull request makes the assumption that wrapping text should not be the default, and is only desired on Alerts. If the intention is all CardTitle components should have text wrapped then numberOfLines can be removed.


In this screenshot the Alert title has wrapText prop set, while the title below does not.
![image](https://github.com/user-attachments/assets/7ead1c5d-e9ec-4a85-bc67-279bef46e499)

This is my first pull request for this project. Any feedback is helpful!