### PR TITLE
feat: add support for pick n pay QRs

### DIFF
--- a/lib/merchants.ts
+++ b/lib/merchants.ts
@@ -1,0 +1,38 @@
+// from https://github.com/GaloyMoney/galoy-client/blob/main/src/parsing/merchants.ts
+
+type MerchantConfig = {
+  id: string;
+  identifierRegex: RegExp;
+  defaultDomain: string;
+};
+
+export const merchants: MerchantConfig[] = [
+  {
+    id: "picknpay",
+    identifierRegex: /(?<identifier>.*za\.co\.electrum\.picknpay.*)/iu,
+    defaultDomain: "cryptoqr.net",
+  },
+  {
+    id: "ecentric",
+    identifierRegex: /(?<identifier>.*za\.co\.ecentric.*)/iu,
+    defaultDomain: "cryptoqr.net",
+  },
+];
+
+export const convertMerchantQRToLightningAddress = (
+  qrContent: string,
+): string | null => {
+  if (!qrContent) {
+    return null;
+  }
+
+  for (const merchant of merchants) {
+    const match = qrContent.match(merchant.identifierRegex);
+    if (match?.groups?.identifier) {
+      const domain = merchant.defaultDomain;
+      return `${encodeURIComponent(match.groups.identifier)}@${domain}`;
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
This adds support for merchant QRs which need to be converted into lightning addresses. Thanks to https://github.com/GaloyMoney/galoy-client/pull/331

**You can try using this QR:**
<img width="200" alt="Screenshot 2025-02-20 at 11 51 34 AM" src="https://github.com/user-attachments/assets/b0bc85b9-2f0d-4fc0-a670-933ad53ba2c4" />


**Or paste:**
`00020129530023ZA.CO.ELECTRUM.PICKNPAY0122RD2HAK3KTI53EC/CONFIRM520458125303710540115802ZA5916CRYPTOQRTESTSCAN6002CT63049BE2`