### PR TITLE
fix: use rn animations instead of reanimated in skeleton

### DIFF
--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,35 +1,36 @@
 import * as React from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { Animated, Easing, ViewProps } from "react-native";
 import { cn } from "~/lib/utils";
 
 const duration = 1000;
 
-function Skeleton({
-  className,
-  ...props
-}: Omit<React.ComponentPropsWithoutRef<typeof Animated.View>, "style">) {
-  const sv = useSharedValue(1);
+function Skeleton({ className, ...props }: Omit<ViewProps, "style">) {
+  const opacity = React.useRef(new Animated.Value(1)).current;
 
   React.useEffect(() => {
-    sv.value = withRepeat(
-      withSequence(withTiming(0.5, { duration }), withTiming(1, { duration })),
-      -1,
+    const pulse = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.5,
+          duration,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      ]),
     );
-  }, [sv]);
-
-  const style = useAnimatedStyle(() => ({
-    opacity: sv.value,
-  }));
+    pulse.start();
+    return () => pulse.stop();
+  }, [opacity]);
 
   return (
     <Animated.View
-      style={style}
+      style={{ opacity }}
       className={cn("rounded-md bg-muted", className)}
       {...props}
     />

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -132,7 +132,7 @@ export function Home() {
                     )}
                   </>
                 ) : (
-                  <Skeleton className="w-48 h-10" />
+                  <Skeleton className="w-48 h-[48px]" />
                 )}
               </View>
               <View className="flex justify-center items-center">
@@ -147,7 +147,7 @@ export function Home() {
                       ) + " sats"}
                   </Text>
                 ) : (
-                  <Skeleton className="w-32 h-8" />
+                  <Skeleton className="w-32 h-[30px]" />
                 )}
               </View>
             </TouchableOpacity>


### PR DESCRIPTION
Skeleton component was using `react-native-reanimated` which was causing some weird layout shifts in android. So I replaced it with react-native's own `Animated.View` component

Also changed the heights of Skeleton to match the font-size of the text it replaces