### PR TITLE
fix: do not show error toasts when in-progress nwc request was backgrounded

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,6 @@ import { toastConfig } from "~/components/ToastConfig";
 import { NotificationProvider } from "~/context/Notification";
 import { UserInactivityProvider } from "~/context/UserInactivity";
 import "~/global.css";
-import { useInfo } from "~/hooks/useInfo";
 import { SessionProvider } from "~/hooks/useSession";
 import { IS_EXPO_GO, NAV_THEME } from "~/lib/constants";
 import { isBiometricSupported } from "~/lib/isBiometricSupported";
@@ -50,8 +49,6 @@ export const unstable_settings = {
 export default function RootLayout() {
   const { isDarkColorScheme, setColorScheme } = useColorScheme();
   const [resourcesLoaded, setResourcesLoaded] = React.useState(false);
-
-  useConnectionChecker();
 
   async function loadFonts() {
     await Font.loadAsync({
@@ -137,16 +134,4 @@ export default function RootLayout() {
       </NotificationProvider>
     </SWRConfig>
   );
-}
-
-function useConnectionChecker() {
-  const { error } = useInfo();
-  React.useEffect(() => {
-    if (error?.message) {
-      Toast.show({
-        type: "connectionError",
-        text1: error.message,
-      });
-    }
-  }, [error?.message]);
 }

--- a/hooks/useBalance.ts
+++ b/hooks/useBalance.ts
@@ -1,21 +1,11 @@
 import { useAppStore } from "lib/state/appStore";
 import useSWR from "swr";
-import { errorToast } from "~/lib/errorToast";
+import { createNwcFetcher } from "~/lib/createNwcFetcher";
 
-type FetchArgs = Parameters<typeof fetch>;
-const fetcher = async (...args: FetchArgs) => {
-  const nwcClient = useAppStore.getState().nwcClient;
-  if (!nwcClient) {
-    throw new Error("No NWC client");
-  }
-  try {
-    const balance = await nwcClient.getBalance();
-    return balance;
-  } catch (error) {
-    errorToast(error);
-    throw error;
-  }
-};
+const fetcher = createNwcFetcher(async (nwcClient) => {
+  const balance = await nwcClient.getBalance();
+  return balance;
+});
 
 export function useBalance() {
   const nwcClient = useAppStore((store) => store.nwcClient);

--- a/hooks/useInfo.ts
+++ b/hooks/useInfo.ts
@@ -1,21 +1,11 @@
 import { useAppStore } from "lib/state/appStore";
 import useSWR from "swr";
-import { errorToast } from "~/lib/errorToast";
+import { createNwcFetcher } from "~/lib/createNwcFetcher";
 
-type FetchArgs = Parameters<typeof fetch>;
-const fetcher = async (...args: FetchArgs) => {
-  const nwcClient = useAppStore.getState().nwcClient;
-  if (!nwcClient) {
-    throw new Error("No NWC client");
-  }
-  try {
-    const info = await nwcClient.getInfo();
-    return info;
-  } catch (error) {
-    errorToast(error);
-    throw error;
-  }
-};
+const fetcher = createNwcFetcher(async (nwcClient) => {
+  const info = await nwcClient.getInfo();
+  return info;
+});
 
 export function useInfo() {
   const nwcClient = useAppStore((store) => store.nwcClient);

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -1,31 +1,18 @@
 import { useAppStore } from "lib/state/appStore";
 import useSWR from "swr";
 import { TRANSACTIONS_PAGE_SIZE } from "~/lib/constants";
-import { errorToast } from "~/lib/errorToast";
+import { createNwcFetcher } from "~/lib/createNwcFetcher";
 
-type FetchArgs = Parameters<typeof fetch>;
-
-const fetcher = async (...args: FetchArgs) => {
-  const nwcClient = useAppStore.getState().nwcClient;
-  if (!nwcClient) {
-    throw new Error("No NWC client");
-  }
-
+const fetcher = createNwcFetcher(async (nwcClient, args) => {
   const transactionsUrl = new URL("http://" + (args[0] as string));
   const page = +(transactionsUrl.searchParams.get("page") as string);
-
-  try {
-    const transactions = await nwcClient.listTransactions({
-      limit: TRANSACTIONS_PAGE_SIZE,
-      offset: (page - 1) * TRANSACTIONS_PAGE_SIZE,
-      unpaid_outgoing: true,
-    });
-    return transactions;
-  } catch (error) {
-    errorToast(error);
-    throw error;
-  }
-};
+  const transactions = await nwcClient.listTransactions({
+    limit: TRANSACTIONS_PAGE_SIZE,
+    offset: (page - 1) * TRANSACTIONS_PAGE_SIZE,
+    unpaid_outgoing: true,
+  });
+  return transactions;
+});
 
 export function useTransactions(page = 1) {
   const nwcClient = useAppStore((store) => store.nwcClient);

--- a/lib/createNwcFetcher.ts
+++ b/lib/createNwcFetcher.ts
@@ -1,0 +1,37 @@
+import { NWCClient } from "@getalby/sdk/dist/NWCClient";
+import { errorToast } from "~/lib/errorToast";
+import { useAppStore } from "~/lib/state/appStore";
+
+type FetchArgs = Parameters<typeof fetch>;
+
+export function createNwcFetcher<T>(
+  fetcherFunc: (nwcClient: NWCClient, args: FetchArgs) => Promise<T>,
+) {
+  return async (...args: FetchArgs) => {
+    const nwcClient = useAppStore.getState().nwcClient;
+    if (!nwcClient) {
+      throw new Error("No NWC client");
+    }
+    const lastAppStateChangeTime =
+      useAppStore.getState().lastAppStateChangeTime;
+    try {
+      const result = await fetcherFunc(nwcClient, args);
+      return result;
+    } catch (error) {
+      if (
+        lastAppStateChangeTime !== useAppStore.getState().lastAppStateChangeTime
+      ) {
+        // the user backgrounded the app, on iOS the websocket connection
+        // is severed
+        console.info(
+          "app was backgrounded while doing NWC request, ignoring error",
+          { error },
+        );
+        throw new Error("app was backgrounded");
+      }
+      console.error("NWC request failed", { error });
+      errorToast(error);
+      throw error;
+    }
+  };
+}

--- a/lib/state/appStore.ts
+++ b/lib/state/appStore.ts
@@ -16,7 +16,9 @@ interface AppState {
   readonly expoPushToken: string;
   readonly theme?: Theme;
   readonly balanceDisplayMode: BalanceDisplayMode;
+  readonly lastAppStateChangeTime: number;
   setUnlocked: (unlocked: boolean) => void;
+  setLastAppStateChangeTime: (lastAppStateChangeTime: number) => void;
   setTheme: (theme: Theme) => void;
   setBalanceDisplayMode: (balanceDisplayMode: BalanceDisplayMode) => void;
   setOnboarded: (isOnboarded: boolean) => void;
@@ -48,7 +50,6 @@ const themeKey = "theme";
 const balanceDisplayModeKey = "balanceDisplayMode";
 const isSecurityEnabledKey = "isSecurityEnabled";
 const isNotificationsEnabledKey = "isNotificationsEnabled";
-export const lastActiveTimeKey = "lastActiveTime";
 
 export type BalanceDisplayMode = "sats" | "fiat" | "hidden";
 export type Theme = "light" | "dark";
@@ -204,6 +205,7 @@ export const useAppStore = create<AppState>()((set, get) => {
     isOnboarded: secureStorage.getItem(hasOnboardedKey) === "true",
     selectedWalletId: initialSelectedWalletId,
     expoPushToken: secureStorage.getItem(expoPushTokenKey) || "",
+    lastAppStateChangeTime: 0,
     updateWallet,
     removeWallet,
     removeAddressBookEntry,
@@ -290,6 +292,10 @@ export const useAppStore = create<AppState>()((set, get) => {
     updateLastAlbyPayment: () => {
       secureStorage.setItem(lastAlbyPaymentKey, new Date().toString());
     },
+    setLastAppStateChangeTime: (lastAppStateChangeTime) =>
+      set({
+        lastAppStateChangeTime,
+      }),
     reset() {
       // clear wallets
       for (let i = 0; i < get().wallets.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/getAlby/go/issues/278

- Does not show toast when error
- Remove unreliable `useConnectionChecker` code which can show a toast even if it was just a network error and the app connection is actually fine
- Replace unnecessary secure storage variable with in memory variable for checking if unlock page should be shown