### PR TITLE
fix: refresh btc rate every 5 minutes

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -29,6 +29,7 @@ export const CURSOR_COLOR = "hsl(47 100% 72%)";
 export const TRANSACTIONS_PAGE_SIZE = 20;
 
 export const DEFAULT_CURRENCY = "USD";
+export const BTC_RATE_REFRESH_INTERVAL = 5 * 60 * 1000;
 export const DEFAULT_WALLET_NAME = "Default Wallet";
 export const ALBY_LIGHTNING_ADDRESS = "go@getalby.com";
 export const ALBY_URL = "https://getalby.com";


### PR DESCRIPTION
Currently we don't refresh btc rates which might result in outdated btc rates if user stays for very long. This PR makes sure it is updated every 5 minutes