### PR TITLE
fix: manually wait for camera ready before initializing

### DIFF
--- a/components/FocusableCamera.tsx
+++ b/components/FocusableCamera.tsx
@@ -8,6 +8,7 @@ type FocusableCameraProps = {
 
 export function FocusableCamera({ onScanned }: FocusableCameraProps) {
   const [autoFocus, setAutoFocus] = React.useState(true);
+  const [isCameraReady, setCameraReady] = React.useState(false);
 
   const focusCamera = () => {
     setAutoFocus(false);
@@ -21,7 +22,9 @@ export function FocusableCamera({ onScanned }: FocusableCameraProps) {
   };
   return (
     <CameraView
-      onBarcodeScanned={handleBarCodeScanned}
+      // TODO: Remove this once expo-camera v16.0.18 is released
+      onCameraReady={() => setCameraReady(true)}
+      onBarcodeScanned={isCameraReady ? handleBarCodeScanned : undefined}
       style={{ flex: 1, width: "100%" }}
       barcodeScannerSettings={{
         barcodeTypes: ["qr"],


### PR DESCRIPTION
Fixes #292 

Related Issues:
https://github.com/expo/expo/issues/35386
https://github.com/expo/expo/issues/34896