### PR TITLE
fix: Return to QR Scanner on Back from Amount Input

### DIFF
--- a/app/(app)/send/manual.js
+++ b/app/(app)/send/manual.js
@@ -1,0 +1,5 @@
+import { Manual } from "../../../pages/send/Manual";
+
+export default function Page() {
+  return <Manual />;
+}

--- a/pages/send/Manual.tsx
+++ b/pages/send/Manual.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import { View } from "react-native";
+import DismissableKeyboardView from "~/components/DismissableKeyboardView";
+import Screen from "~/components/Screen";
+import { Input } from "~/components/ui/input";
+import { Text } from "~/components/ui/text";
+import { Button } from "~/components/ui/button";
+import { errorToast } from "~/lib/errorToast";
+import { processPayment } from "~/lib/processPayment";
+
+export function Manual() {
+  const [keyboardText, setKeyboardText] = useState("");
+
+  const submitKeyboardText = async () => {
+    if (!keyboardText) {
+      errorToast(new Error("Input is empty."));
+      return;
+    }
+    try {
+      await processPayment(keyboardText, "");
+    } catch (error) {
+      console.error("Payment failed:", error);
+      errorToast(error);
+    }
+  };
+
+  return (
+    <>
+      <Screen title="Manual" />
+      <DismissableKeyboardView>
+        <View className="flex-1 h-full flex flex-col gap-5 p-6">
+          <View className="flex-1 flex items-center justify-center">
+            <Text className="text-muted-foreground text-center">
+              Type or paste a Lightning Address, lightning invoice or LNURL.
+            </Text>
+            <Input
+              className="w-full text-center mt-6 border-transparent bg-transparent native:text-2xl font-semibold2"
+              placeholder="hello@getalby.com"
+              value={keyboardText}
+              onChangeText={setKeyboardText}
+              inputMode="email"
+              autoFocus
+              returnKeyType="done"
+            />
+          </View>
+          <Button onPress={submitKeyboardText} size="lg">
+            <Text>Next</Text>
+          </Button>
+        </View>
+      </DismissableKeyboardView>
+    </>
+  );
+}

--- a/pages/send/Manual.tsx
+++ b/pages/send/Manual.tsx
@@ -12,10 +12,6 @@ export function Manual() {
   const [keyboardText, setKeyboardText] = useState("");
 
   const submitKeyboardText = async () => {
-    if (!keyboardText) {
-      errorToast(new Error("Input is empty."));
-      return;
-    }
     try {
       await processPayment(keyboardText, "");
     } catch (error) {
@@ -43,7 +39,11 @@ export function Manual() {
               returnKeyType="done"
             />
           </View>
-          <Button onPress={submitKeyboardText} size="lg">
+          <Button
+            onPress={submitKeyboardText}
+            disabled={!keyboardText}
+            size="lg"
+          >
             <Text>Next</Text>
           </Button>
         </View>

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -2,13 +2,11 @@ import * as Clipboard from "expo-clipboard";
 import { router, useLocalSearchParams } from "expo-router";
 import React from "react";
 import { View } from "react-native";
-import DismissableKeyboardView from "~/components/DismissableKeyboardView";
 import { BookUserIcon, KeyboardIcon, PasteIcon } from "~/components/Icons";
 import Loading from "~/components/Loading";
 import QRCodeScanner from "~/components/QRCodeScanner";
 import Screen from "~/components/Screen";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 import { Text } from "~/components/ui/text";
 import { errorToast } from "~/lib/errorToast";
 import { handleLink } from "~/lib/link";
@@ -21,8 +19,6 @@ export function Send() {
   }>();
 
   const [isLoading, setLoading] = React.useState(false);
-  const [keyboardOpen, setKeyboardOpen] = React.useState(false);
-  const [keyboardText, setKeyboardText] = React.useState("");
   const [startScanning, setStartScanning] = React.useState(false);
 
   async function paste() {
@@ -39,14 +35,6 @@ export function Send() {
   const handleScanned = async (data: string) => {
     return loadPayment(data);
   };
-
-  function openKeyboard() {
-    setKeyboardOpen(true);
-  }
-
-  function submitKeyboardText() {
-    loadPayment(keyboardText);
-  }
 
   const loadPayment = async (text: string, amount = "") => {
     if (!text) {
@@ -90,67 +78,40 @@ export function Send() {
       )}
       {!isLoading && (
         <>
-          {!keyboardOpen && (
-            <>
-              <QRCodeScanner
-                onScanned={handleScanned}
-                startScanning={startScanning}
-              />
-              <View className="flex flex-row items-stretch justify-center gap-4 p-6">
-                <Button
-                  onPress={openKeyboard}
-                  variant="secondary"
-                  className="flex flex-col gap-2 flex-1"
-                >
-                  <KeyboardIcon className="text-muted-foreground" />
-                  <Text numberOfLines={1}>Manual</Text>
-                </Button>
-                <Button
-                  variant="secondary"
-                  className="flex flex-col gap-2 flex-1"
-                  onPress={() => {
-                    router.push("/send/address-book");
-                  }}
-                >
-                  <BookUserIcon className="text-muted-foreground" />
-                  <Text numberOfLines={1}>Contacts</Text>
-                </Button>
-                <Button
-                  onPress={paste}
-                  variant="secondary"
-                  className="flex flex-col gap-2 flex-1"
-                >
-                  <PasteIcon className="text-muted-foreground" />
-                  <Text numberOfLines={1}>Paste</Text>
-                </Button>
-              </View>
-            </>
-          )}
-          {keyboardOpen && (
-            <DismissableKeyboardView>
-              <View className="flex-1 h-full flex flex-col gap-5 p-6">
-                <View className="flex-1 flex items-center justify-center">
-                  <Text className="text-muted-foreground text-center">
-                    Type or paste a Lightning Address, lightning invoice or
-                    LNURL.
-                  </Text>
-                  <Input
-                    className="w-full text-center mt-6 border-transparent bg-transparent native:text-2xl font-semibold2"
-                    placeholder="hello@getalby.com"
-                    value={keyboardText}
-                    onChangeText={setKeyboardText}
-                    inputMode="email"
-                    autoFocus
-                    returnKeyType="done"
-                    // aria-errormessage="inputError"
-                  />
-                </View>
-                <Button onPress={submitKeyboardText} size="lg">
-                  <Text>Next</Text>
-                </Button>
-              </View>
-            </DismissableKeyboardView>
-          )}
+          <QRCodeScanner
+            onScanned={handleScanned}
+            startScanning={startScanning}
+          />
+          <View className="flex flex-row items-stretch justify-center gap-4 p-6">
+            <Button
+              onPress={() => {
+                router.push("/send/manual");
+              }}
+              variant="secondary"
+              className="flex flex-col gap-2 flex-1"
+            >
+              <KeyboardIcon className="text-muted-foreground" />
+              <Text numberOfLines={1}>Manual</Text>
+            </Button>
+            <Button
+              variant="secondary"
+              className="flex flex-col gap-2 flex-1"
+              onPress={() => {
+                router.push("/send/address-book");
+              }}
+            >
+              <BookUserIcon className="text-muted-foreground" />
+              <Text numberOfLines={1}>Contacts</Text>
+            </Button>
+            <Button
+              onPress={paste}
+              variant="secondary"
+              className="flex flex-col gap-2 flex-1"
+            >
+              <PasteIcon className="text-muted-foreground" />
+              <Text numberOfLines={1}>Paste</Text>
+            </Button>
+          </View>
         </>
       )}
     </>


### PR DESCRIPTION
## Description

Hey folks! I spotted a little navigation quirk in the Send screen, hitting the back button from the Amount input dumps you back to the main screen, while Contacts and Paste return you to the QR scanner. It felt jarring, so I added a `BackHandler` to `Send.tsx` to catch the back press when `keyboardOpen` is true, flipping it to false to keep you in the QR flow. Tested it on my Android 14(API 34).

## Steps to Reproduce

1. Open Alby Go and tap “Send.”
2. Hit the “Amount” button to bring up the input view.
3. Press the hardware back button : before this fix, you’d land on the main screen instead of the QR scanner.

## Videos

- **Before**: [Video](https://drive.google.com/file/d/1eZ0d_i86M13SQP62a1Wgwn5rFwlPunHX/view?usp=sharing) : Back press kicks you to the main screen
- **After**: [Video](https://drive.google.com/file/d/1k8mjk_nhiOqWFHS6yRNRFpLOB9S2A0ny/view?usp=sharing) : Back press lands you back on the QR scanner

This little tweak keeps the Send flow consistent and user-friendly. I’ve marked it as a draft since I’d love to hear if this matches the UX requirements and if this requires amy changes.