### PR TITLE
fix: improve send logic

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -13,6 +13,7 @@ import {
   PopiconsUploadSolid as ExportIcon,
   PopiconsTouchIdSolid as FingerprintIcon,
   PopiconsCircleInfoSolid as HelpCircleIcon,
+  PopiconsKeyboardSolid as KeyboardIcon,
   PopiconsLinkExternalSolid as LinkIcon,
   PopiconsArrowDownLine as MoveDownIcon,
   PopiconsArrowUpLine as MoveUpIcon,
@@ -65,6 +66,7 @@ interopIcon(EditIcon);
 interopIcon(ExportIcon);
 interopIcon(FingerprintIcon);
 interopIcon(HelpCircleIcon);
+interopIcon(KeyboardIcon);
 interopIcon(LinkIcon);
 interopIcon(MoveDownIcon);
 interopIcon(MoveUpIcon);
@@ -103,6 +105,7 @@ export {
   ExportIcon,
   FingerprintIcon,
   HelpCircleIcon,
+  KeyboardIcon,
   LinkIcon,
   MoveDownIcon,
   MoveUpIcon,

--- a/components/Receiver.tsx
+++ b/components/Receiver.tsx
@@ -3,14 +3,14 @@ import { View } from "react-native";
 import { Text } from "~/components/ui/text";
 
 interface ReceiverProps {
-  originalText: string;
+  name: string;
   invoice?: string;
 }
 
-export function Receiver({ originalText, invoice }: ReceiverProps) {
+export function Receiver({ name, invoice }: ReceiverProps) {
   const shouldShowReceiver =
-    originalText !== invoice &&
-    originalText.toLowerCase().replace("lightning:", "").includes("@");
+    name !== invoice &&
+    name.toLowerCase().replace("lightning:", "").includes("@");
 
   if (!shouldShowReceiver) {
     return null;
@@ -22,7 +22,7 @@ export function Receiver({ originalText, invoice }: ReceiverProps) {
         To
       </Text>
       <Text className="text-center text-foreground text-2xl font-medium2">
-        {originalText.toLowerCase().replace("lightning:", "")}
+        {name.toLowerCase().replace("lightning:", "")}
       </Text>
     </View>
   );

--- a/lib/link.ts
+++ b/lib/link.ts
@@ -159,9 +159,10 @@ export const handleLink = async (url: string) => {
 
       if (lnurlDetails.tag === "payRequest") {
         router.push({
-          pathname: "/send",
+          pathname: "/send/lnurl-pay",
           params: {
-            url: lnurl,
+            lnurlDetailsJSON: JSON.stringify(lnurlDetails),
+            receiver: lnurl,
           },
         });
         return;

--- a/lib/processPayment.ts
+++ b/lib/processPayment.ts
@@ -1,0 +1,97 @@
+import { Invoice } from "@getalby/lightning-tools";
+import { router } from "expo-router";
+import { lnurl as lnurlLib } from "lib/lnurl";
+import { errorToast } from "~/lib/errorToast";
+import { convertMerchantQRToLightningAddress } from "~/lib/merchants";
+
+export async function processPayment(
+  text: string,
+  amount: string,
+): Promise<boolean> {
+  // Some apps use uppercased LIGHTNING: prefixes
+  text = text.toLowerCase();
+  console.info("loading payment", text);
+  const originalText = text;
+
+  try {
+    if (text.startsWith("bitcoin:")) {
+      const universalUrl = text.replace("bitcoin:", "http://");
+      const url = new URL(universalUrl);
+      const lightningParam = url.searchParams.get("lightning");
+      if (!lightningParam) {
+        throw new Error("No lightning param found in bitcoin payment link");
+      }
+      text = lightningParam;
+    }
+
+    if (text.startsWith("lightning:")) {
+      text = text.substring("lightning:".length);
+    }
+
+    // convert picknpay QRs to lighnting addresses
+    const merchantLightningAddress = convertMerchantQRToLightningAddress(text);
+    if (merchantLightningAddress) {
+      text = merchantLightningAddress;
+    }
+
+    const lnurl = lnurlLib.findLnurl(text);
+    console.info("Checked lnurl value", text, lnurl);
+
+    if (lnurl) {
+      const lnurlDetails = await lnurlLib.getDetails(lnurl);
+
+      if (
+        lnurlDetails.tag !== "payRequest" &&
+        lnurlDetails.tag !== "withdrawRequest"
+      ) {
+        throw new Error("LNURL tag not supported");
+      }
+
+      if (lnurlDetails.tag === "withdrawRequest") {
+        router.replace({
+          pathname: "/withdraw",
+          params: { url: lnurl },
+        });
+        return true;
+      }
+
+      if (lnurlDetails.tag === "payRequest") {
+        router.replace({
+          pathname: "/send/lnurl-pay",
+          params: {
+            lnurlDetailsJSON: JSON.stringify(lnurlDetails),
+            receiver: lnurl,
+            amount,
+          },
+        });
+        return true;
+      }
+    } else {
+      // Check if this is a valid invoice
+      const invoice = new Invoice({ pr: text });
+
+      if (invoice.satoshi === 0) {
+        router.replace({
+          pathname: "/send/0-amount",
+          params: {
+            invoice: text,
+            receiver: originalText,
+            comment: invoice.description,
+          },
+        });
+        return true;
+      }
+
+      router.replace({
+        pathname: "/send/confirm",
+        params: { invoice: text, receiver: originalText },
+      });
+      return true;
+    }
+  } catch (error) {
+    console.error("failed to load payment", originalText, error);
+    errorToast(error);
+  }
+
+  return false;
+}

--- a/pages/send/ConfirmPayment.tsx
+++ b/pages/send/ConfirmPayment.tsx
@@ -19,10 +19,10 @@ import { useAppStore } from "~/lib/state/appStore";
 
 export function ConfirmPayment() {
   const { data: transactions } = useTransactions();
-  const { invoice, originalText, comment, successAction, amount } =
+  const { invoice, receiver, comment, successAction, amount } =
     useLocalSearchParams() as {
       invoice: string;
-      originalText: string;
+      receiver: string;
       comment: string;
       successAction: string;
       amount?: string;
@@ -50,7 +50,7 @@ export function ConfirmPayment() {
 
       console.info("payInvoice Response", response);
 
-      if (originalText === ALBY_LIGHTNING_ADDRESS) {
+      if (receiver === ALBY_LIGHTNING_ADDRESS) {
         useAppStore.getState().updateLastAlbyPayment();
       }
 
@@ -59,7 +59,7 @@ export function ConfirmPayment() {
         pathname: "/send/success",
         params: {
           preimage: response.preimage,
-          originalText,
+          receiver,
           invoice,
           amount: amountToPaySats,
           successAction,
@@ -112,7 +112,7 @@ export function ConfirmPayment() {
             </View>
           )
         )}
-        <Receiver originalText={originalText} invoice={invoice} />
+        <Receiver name={receiver} invoice={invoice} />
       </View>
       <View className="p-6 bg-background">
         <WalletSwitcher selectedWalletId={selectedWalletId} wallets={wallets} />

--- a/pages/send/LNURLPay.tsx
+++ b/pages/send/LNURLPay.tsx
@@ -1,6 +1,7 @@
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useEffect } from "react";
 import { View } from "react-native";
+import Toast from "react-native-toast-message";
 import DismissableKeyboardView from "~/components/DismissableKeyboardView";
 import { DualCurrencyInput } from "~/components/DualCurrencyInput";
 import Loading from "~/components/Loading";
@@ -41,6 +42,11 @@ export function LNURLPay() {
     if (lnurlDetails.minSendable === lnurlDetails.maxSendable) {
       setAmount((lnurlDetails.minSendable / 1000).toString());
       setAmountReadOnly(true);
+      Toast.show({
+        type: "success",
+        text1: "You are paying a fixed amount invoice",
+        position: "top",
+      });
     }
   }, [lnurlDetails.minSendable, lnurlDetails.maxSendable]);
 
@@ -105,18 +111,20 @@ export function LNURLPay() {
                 sats
               </Text>
             </View>
-            <View className="w-full">
-              <Text className="text-muted-foreground text-center font-semibold2">
-                Comment
-              </Text>
-              <Input
-                className="w-full border-transparent bg-transparent text-center native:text-2xl font-semibold2"
-                placeholder="Enter an optional comment"
-                value={comment}
-                onChangeText={setComment}
-                returnKeyType="done"
-              />
-            </View>
+            {!!lnurlDetails.commentAllowed && (
+              <View className="w-full">
+                <Text className="text-muted-foreground text-center font-semibold2">
+                  Comment
+                </Text>
+                <Input
+                  className="w-full border-transparent bg-transparent text-center native:text-2xl font-semibold2"
+                  placeholder="Enter an optional comment"
+                  value={comment}
+                  onChangeText={setComment}
+                  returnKeyType="done"
+                />
+              </View>
+            )}
             <Receiver originalText={originalText} />
           </View>
           <View className="p-6">

--- a/pages/send/LNURLPay.tsx
+++ b/pages/send/LNURLPay.tsx
@@ -17,11 +17,11 @@ import { cn } from "~/lib/utils";
 export function LNURLPay() {
   const {
     lnurlDetailsJSON,
-    originalText,
+    receiver,
     amount: amountParam,
   } = useLocalSearchParams() as unknown as {
     lnurlDetailsJSON: string;
-    originalText: string;
+    receiver: string;
     amount: string;
   };
   const lnurlDetails: LNURLPayServiceResponse = JSON.parse(lnurlDetailsJSON);
@@ -65,7 +65,7 @@ export function LNURLPay() {
         pathname: "/send/confirm",
         params: {
           invoice: lnurlPayInfo.pr,
-          originalText,
+          receiver,
           comment,
           successAction: lnurlPayInfo.successAction
             ? JSON.stringify(lnurlPayInfo.successAction)
@@ -125,7 +125,7 @@ export function LNURLPay() {
                 />
               </View>
             )}
-            <Receiver originalText={originalText} />
+            <Receiver name={receiver} />
           </View>
           <View className="p-6">
             <Button

--- a/pages/send/PaymentSuccess.tsx
+++ b/pages/send/PaymentSuccess.tsx
@@ -13,10 +13,10 @@ import { useGetFiatAmount } from "~/hooks/useGetFiatAmount";
 
 export function PaymentSuccess() {
   const getFiatAmount = useGetFiatAmount();
-  const { originalText, invoice, amount, successAction } =
+  const { receiver, invoice, amount, successAction } =
     useLocalSearchParams() as {
       preimage: string;
-      originalText: string;
+      receiver: string;
       invoice: string;
       amount: string;
       successAction: string;
@@ -49,7 +49,7 @@ export function PaymentSuccess() {
             </Text>
           )}
         </View>
-        <Receiver originalText={originalText} invoice={invoice} />
+        <Receiver name={receiver} invoice={invoice} />
         {lnurlSuccessAction && (
           <View className="flex flex-col gap-2 items-center">
             <Text className="text-muted-foreground text-center font-semibold2">

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -3,7 +3,7 @@ import { router, useLocalSearchParams } from "expo-router";
 import React from "react";
 import { View } from "react-native";
 import DismissableKeyboardView from "~/components/DismissableKeyboardView";
-import { BookUserIcon, EditIcon, PasteIcon } from "~/components/Icons";
+import { BookUserIcon, KeyboardIcon, PasteIcon } from "~/components/Icons";
 import Loading from "~/components/Loading";
 import QRCodeScanner from "~/components/QRCodeScanner";
 import Screen from "~/components/Screen";
@@ -102,8 +102,8 @@ export function Send() {
                   variant="secondary"
                   className="flex flex-col gap-2 flex-1"
                 >
-                  <EditIcon className="text-muted-foreground" />
-                  <Text numberOfLines={1}>Amount</Text>
+                  <KeyboardIcon className="text-muted-foreground" />
+                  <Text numberOfLines={1}>Manual</Text>
                 </Button>
                 <Button
                   variant="secondary"

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -110,32 +110,14 @@ export function Send() {
             return true;
           }
 
-          // Handle fixed amount LNURLs
-          if (
-            lnurlDetails.minSendable === lnurlDetails.maxSendable &&
-            !lnurlDetails.commentAllowed
-          ) {
-            const callback = new URL(lnurlDetails.callback);
-            callback.searchParams.append(
-              "amount",
-              lnurlDetails.minSendable.toString(),
-            );
-            const lnurlPayInfo = await lnurl.getPayRequest(callback.toString());
-            router.replace({
-              pathname: "/send/confirm",
-              params: { invoice: lnurlPayInfo.pr, originalText },
-            });
-          } else {
-            router.replace({
-              pathname: "/send/lnurl-pay",
-              params: {
-                lnurlDetailsJSON: JSON.stringify(lnurlDetails),
-                originalText,
-                amount,
-              },
-            });
-          }
-
+          router.replace({
+            pathname: "/send/lnurl-pay",
+            params: {
+              lnurlDetailsJSON: JSON.stringify(lnurlDetails),
+              originalText,
+              amount,
+            },
+          });
           return true;
         } else {
           // Check if this is a valid invoice

--- a/pages/send/ZeroAmount.tsx
+++ b/pages/send/ZeroAmount.tsx
@@ -11,12 +11,11 @@ import { Text } from "~/components/ui/text";
 import { errorToast } from "~/lib/errorToast";
 
 export function ZeroAmount() {
-  const { invoice, originalText, comment } =
-    useLocalSearchParams() as unknown as {
-      invoice: string;
-      originalText: string;
-      comment: string;
-    };
+  const { invoice, receiver, comment } = useLocalSearchParams() as unknown as {
+    invoice: string;
+    receiver: string;
+    comment: string;
+  };
   const [isLoading, setLoading] = React.useState(false);
   const [amount, setAmount] = React.useState("");
 
@@ -27,7 +26,7 @@ export function ZeroAmount() {
         pathname: "/send/confirm",
         params: {
           invoice,
-          originalText,
+          receiver,
           amount,
         },
       });
@@ -63,7 +62,7 @@ export function ZeroAmount() {
                 </Text>
               </View>
             )}
-            <Receiver originalText={originalText} />
+            <Receiver name={receiver} />
           </View>
           <View className="p-6">
             <Button


### PR DESCRIPTION
Has some chores + performance improvements related to Send logic

https://github.com/getAlby/go/commit/6bb297cabe128d76eb85a0f30844c1c8b54a895b: Removes duplication regarding fixed amount invoices

https://github.com/getAlby/go/commit/8608c916f87d02fa3defdabbb9d15b2b621efc85: Fixes comment by not allowing if `commentAllowed` is `0`

https://github.com/getAlby/go/commit/7df77e8f90e480b5d520988b647d2d1f70c8bf8c: Sends directly to lnurl-pay since currently we are fetching lnurl details twice

https://github.com/getAlby/go/commit/27600582e1e566a78a30310379b982d4f9804249: Minor naming change as `originalText` was looking ugly

https://github.com/getAlby/go/commit/5c93c377c958c39f26f67e799ba71ba312f1f69e: This is to make `Send.tsx` look more readable and also helps [this PR](https://github.com/getAlby/go/pull/307) to make a new screen for manual entering

https://github.com/getAlby/go/commit/05b5dab180c7fa44bc3675458351d4cefc0d16e0: Replaces Amount button text with Manual (and also replaces icon)
