### PR TITLE
feat: Add QR Image Payment

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -13,6 +13,7 @@ import {
   PopiconsUploadSolid as ExportIcon,
   PopiconsTouchIdSolid as FingerprintIcon,
   PopiconsCircleInfoSolid as HelpCircleIcon,
+  PopiconsImageSolid as ImageIcon,
   PopiconsKeyboardSolid as KeyboardIcon,
   PopiconsLinkExternalSolid as LinkIcon,
   PopiconsArrowDownLine as MoveDownIcon,
@@ -66,6 +67,7 @@ interopIcon(EditIcon);
 interopIcon(ExportIcon);
 interopIcon(FingerprintIcon);
 interopIcon(HelpCircleIcon);
+interopIcon(ImageIcon);
 interopIcon(KeyboardIcon);
 interopIcon(LinkIcon);
 interopIcon(MoveDownIcon);
@@ -105,6 +107,7 @@ export {
   ExportIcon,
   FingerprintIcon,
   HelpCircleIcon,
+  ImageIcon,
   KeyboardIcon,
   LinkIcon,
   MoveDownIcon,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "expo-constants": "~17.0.8",
     "expo-device": "~7.0.3",
     "expo-font": "~13.0.4",
+    "expo-image-picker": "^16.1.4",
     "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.5",
     "expo-local-authentication": "~15.0.2",

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -1,8 +1,10 @@
+import { Camera } from "expo-camera";
 import * as Clipboard from "expo-clipboard";
+import * as ImagePicker from "expo-image-picker";
 import { router, useLocalSearchParams } from "expo-router";
 import React from "react";
-import { View } from "react-native";
-import { BookUserIcon, KeyboardIcon, PasteIcon } from "~/components/Icons";
+import { Alert, View } from "react-native";
+import { ImageIcon, KeyboardIcon, PasteIcon } from "~/components/Icons";
 import Loading from "~/components/Loading";
 import QRCodeScanner from "~/components/QRCodeScanner";
 import Screen from "~/components/Screen";
@@ -20,6 +22,48 @@ export function Send() {
 
   const [isLoading, setLoading] = React.useState(false);
   const [startScanning, setStartScanning] = React.useState(false);
+
+  async function pickImage() {
+    const permissionResult =
+      await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (permissionResult.granted === false) {
+      Alert.alert(
+        "Permission Required",
+        "Permission to access camera roll is required!",
+      );
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      setLoading(true);
+      try {
+        const scannedCodes = await Camera.scanFromURLAsync(
+          result.assets[0].uri,
+        );
+        if (scannedCodes.length > 0 && scannedCodes[0].data) {
+          await loadPayment(scannedCodes[0].data);
+        } else {
+          Alert.alert(
+            "No QR Code Found",
+            "Could not find a QR code in the selected image.",
+          );
+        }
+      } catch (error) {
+        console.error("Error scanning image:", error);
+        Alert.alert(
+          "Error Scanning Image",
+          "An error occurred while trying to scan the image for a QR code.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+  }
 
   async function paste() {
     let clipboardText;
@@ -91,17 +135,7 @@ export function Send() {
               className="flex flex-col gap-2 flex-1"
             >
               <KeyboardIcon className="text-muted-foreground" />
-              <Text numberOfLines={1}>Manual</Text>
-            </Button>
-            <Button
-              variant="secondary"
-              className="flex flex-col gap-2 flex-1"
-              onPress={() => {
-                router.push("/send/address-book");
-              }}
-            >
-              <BookUserIcon className="text-muted-foreground" />
-              <Text numberOfLines={1}>Contacts</Text>
+              <Text numberOfLines={1}>Manual / Contacts</Text>
             </Button>
             <Button
               onPress={paste}
@@ -110,6 +144,14 @@ export function Send() {
             >
               <PasteIcon className="text-muted-foreground" />
               <Text numberOfLines={1}>Paste</Text>
+            </Button>
+            <Button
+              onPress={pickImage}
+              variant="secondary"
+              className="flex flex-col gap-2 flex-1"
+            >
+              <ImageIcon className="text-muted-foreground" />
+              <Text numberOfLines={1}>Choose Image</Text>
             </Button>
           </View>
         </>

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -36,7 +36,7 @@ export function Send() {
     }
 
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ["images"],
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "jsx": "react",
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4537,6 +4537,18 @@ expo-font@~13.0.4:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-image-loader@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-5.1.0.tgz#f7d65f9b9a9714eaaf5d50a406cb34cb25262153"
+  integrity sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==
+
+expo-image-picker@^16.1.4:
+  version "16.1.4"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-16.1.4.tgz#d4ac2d1f64f6ec9347c3f64f8435b40e6e4dcc40"
+  integrity sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==
+  dependencies:
+    expo-image-loader "~5.1.0"
+
 expo-keep-awake@~14.0.3:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-14.0.3.tgz#74c91b68effdb6969bc1e8371621aad90386cfbf"


### PR DESCRIPTION
This PR adds the ability to scan QR codes for payments directly from images stored in the user's photo library, expanding payment options beyond live camera scanning.

- Modified the Send screen (pages/send/Send.tsx):
    - Merged "Manual" and "Contacts" buttons into a single "Manual / Contacts" button.
    - Added a new "Choose Image" button.
- Added `PopiconsImageSolid as ImageIcon` to `components/Icons.tsx`
- Added permission handling for image library access.
