### PR TITLE
fix: use transaction type instead of state for tx title

### DIFF
--- a/components/TransactionItem.tsx
+++ b/components/TransactionItem.tsx
@@ -17,17 +17,16 @@ type Props = {
 
 export function TransactionItem({ tx }: Props) {
   const metadata = tx.metadata;
-  const type = tx.type;
   const getFiatAmount = useGetFiatAmount();
 
   const typeStateText =
-    type === "incoming"
-      ? "Received"
-      : tx.state === "settled" // we only fetch settled incoming payments
-        ? "Sent"
-        : tx.state === "pending"
-          ? "Sending"
-          : "Failed";
+    tx.state === "failed"
+      ? "Failed"
+      : tx.state === "pending"
+        ? "Sending"
+        : tx.type === "outgoing"
+          ? "Sent"
+          : "Received";
 
   const Icon =
     tx.state === "failed"


### PR DESCRIPTION
Fixes #329

We currently decide the transaction title based on non-NIP-47 compliant field (`state`), which causes nip47 wallets without `state` property to show wrong information in the title like `"Failed"` instead of `"Sent"`