### PR TITLE
add support for bootleggers coffee bar

### DIFF
--- a/lib/merchants.ts
+++ b/lib/merchants.ts
@@ -17,6 +17,11 @@ export const merchants: MerchantConfig[] = [
     identifierRegex: /(?<identifier>.*za\.co\.ecentric.*)/iu,
     defaultDomain: "cryptoqr.net",
   },
+  {
+    id: "bootleggers",
+    identifierRegex: /(?<identifier>.*(wigroup\.co|yoyogroup\.co).*)/iu,
+    defaultDomain: "cryptoqr.net",
+  },
 ];
 
 export const convertMerchantQRToLightningAddress = (


### PR DESCRIPTION
Moneybadger has added Bootleggers Coffee to our merchant network, and we are sponsoring Bitcoin meetups there across the country. https://www.moneybadger.co.za/meetups

Naturally, one big thing we get asked for is when Alby will work the way it does at PnP :)