### PR TITLE
fix: slide animation in android

### DIFF
--- a/components/AlbyBanner.tsx
+++ b/components/AlbyBanner.tsx
@@ -1,9 +1,9 @@
-import { router } from "expo-router";
 import { useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { XIcon } from "~/components/Icons";
 import { Text } from "~/components/ui/text";
 import { ALBY_LIGHTNING_ADDRESS } from "~/lib/constants";
+import { initiatePaymentFlow } from "~/lib/initiatePaymentFlow";
 import { useAppStore } from "~/lib/state/appStore";
 import { Button } from "./ui/button";
 
@@ -54,14 +54,11 @@ function AlbyBanner() {
             variant="secondary"
             size="sm"
             className="flex-1"
-            onPress={() => {
-              router.navigate({
-                pathname: "/send",
-                params: {
-                  url: ALBY_LIGHTNING_ADDRESS,
-                  amount: value,
-                },
-              });
+            onPress={async () => {
+              await initiatePaymentFlow(
+                ALBY_LIGHTNING_ADDRESS,
+                value.toString(),
+              );
             }}
           >
             <Text>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,9 +1,9 @@
 import { darken, lighten } from "colorizr";
-import { router } from "expo-router";
 import pastellify from "pastellify";
 import { TouchableOpacity, View } from "react-native";
 import { TrashLineIcon } from "~/components/Icons";
 import { Text } from "~/components/ui/text";
+import { initiatePaymentFlow } from "~/lib/initiatePaymentFlow";
 
 export default function Contact({
   lnAddress,
@@ -17,13 +17,8 @@ export default function Contact({
   return (
     <TouchableOpacity
       className="flex flex-row items-center gap-4 px-6 py-4"
-      onPress={() => {
-        router.navigate({
-          pathname: "/send",
-          params: {
-            url: lnAddress,
-          },
-        });
+      onPress={async () => {
+        await initiatePaymentFlow(lnAddress);
       }}
     >
       <View

--- a/components/Screen.tsx
+++ b/components/Screen.tsx
@@ -17,7 +17,7 @@ function Screen({ title, animation, right, left }: ScreenProps) {
     <Stack.Screen
       options={{
         title,
-        animation,
+        animation: animation ? animation : "slide_from_right",
         headerLeft: left
           ? left
           : ({ canGoBack }) => {

--- a/lib/initiatePaymentFlow.ts
+++ b/lib/initiatePaymentFlow.ts
@@ -6,7 +6,7 @@ import { convertMerchantQRToLightningAddress } from "~/lib/merchants";
 
 export async function initiatePaymentFlow(
   text: string,
-  amount: string,
+  amount = "",
 ): Promise<boolean> {
   // Some apps use uppercased LIGHTNING: prefixes
   text = text.toLowerCase();


### PR DESCRIPTION
Fixes slide from right animation not present in android (in iOS it is default)

Also optimizes some screens to avoid sliding twice: first to loading screen (`/send`) and then to amount input again (`/send/lnurl-pay`)