### PR TITLE
chore: add placeholder to dual currency input

### DIFF
--- a/components/DualCurrencyInput.tsx
+++ b/components/DualCurrencyInput.tsx
@@ -299,7 +299,17 @@ export function DualCurrencyInput({
                 validationMessage && "text-destructive",
               )}
             >
-              {text ? formattedText : inputMode === "sats" ? "0" : "0.00"}
+              {text
+                ? formattedText
+                : inputMode === "sats"
+                  ? min
+                    ? max
+                      ? `${min}-${max}`
+                      : `Min ${min}`
+                    : max
+                      ? `Max ${max}`
+                      : "0"
+                  : "0.00"}
             </Text>
             {inputMode === "sats" && (
               <Text


### PR DESCRIPTION
## Screenshots

<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/2e0a688a-9036-4bd2-bc32-13b940c611a7" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/c43017e7-f633-4bb1-a3f1-cc932bb7f71b" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/541ef047-b532-4756-adf1-d02aab0cdcdb" />
</td>
</tr>
</table>