### PR TITLE
fix: stop links from being processed twice

### DIFF
--- a/hooks/useHandleLinking.ts
+++ b/hooks/useHandleLinking.ts
@@ -1,5 +1,4 @@
 import * as Linking from "expo-linking";
-import { getInitialURL } from "expo-linking";
 import { useEffect } from "react";
 import { handleLink } from "~/lib/link";
 import { useAppStore } from "~/lib/state/appStore";
@@ -9,6 +8,7 @@ export function useHandleLinking() {
   const { hasSession } = useSession();
   const isOnboarded = useAppStore((store) => store.isOnboarded);
   const wallets = useAppStore((store) => store.wallets);
+  const url = Linking.useLinkingURL();
 
   useEffect(() => {
     // Do not process any deep links until the user is onboarded and authenticated
@@ -17,22 +17,10 @@ export function useHandleLinking() {
       return;
     }
 
-    const processInitialURL = async () => {
-      const url = await getInitialURL();
+    (async () => {
       if (url) {
         await handleLink(url);
       }
-    };
-
-    processInitialURL();
-
-    const subscription = Linking.addEventListener(
-      "url",
-      async (event: { url: string }) => {
-        await handleLink(event.url);
-      },
-    );
-
-    return () => subscription.remove();
-  }, [hasSession, isOnboarded, wallets.length]);
+    })();
+  }, [url, hasSession, isOnboarded, wallets.length]);
 }


### PR DESCRIPTION
This fixes the issue where Alby Go mistakenly opens the last invoice's confirm payment screen even after scanning a new one (given the app is not closed in between)