### PR TITLE
fix: camera not opening in send screen

### DIFF
--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -104,13 +104,11 @@ export function Send() {
   React.useEffect(() => {
     if (url) {
       (async () => {
-        const result = await loadPayment(url, amount);
+        await loadPayment(url, amount);
         // Delay the camera to show the error message
-        if (!result) {
-          setTimeout(() => {
-            setStartScanning(true);
-          }, 2000);
-        }
+        setTimeout(() => {
+          setStartScanning(true);
+        }, 2000);
       })();
     } else {
       setStartScanning(true);


### PR DESCRIPTION
This fixes send screen being stuck on loading camera screen when you open the app from an `alby:` etc. link and go back (from confirm payment screen)