### PR TITLE
Fix/receive button layout

### DIFF
--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -365,6 +365,7 @@ function MainButton({
               <Icon />
               <Text
                 numberOfLines={1}
+                adjustsFontSizeToFit
                 className={cn(
                   Platform.select({
                     ios: "ios:text-2xl ios:sm:text-3xl",


### PR DESCRIPTION
This PR fixes a UI layout issue #421 where the "Receive" button text would wrap to a second line on certain devices (e.g., iPhone 15), breaking the button alignment.