### PR TITLE
feat: use metadata.comment as fallback for push notification description

### DIFF
--- a/assets/android/MessagingService.kt
+++ b/assets/android/MessagingService.kt
@@ -161,8 +161,11 @@ class MessagingService : FirebaseMessagingService(), OnInitListener {
         val formattedAmount = if (bitcoinDisplayMode == "bip177") "₿ $amount" else "$amount sats"
 
         var descriptionText = notification.optString("description", "")
-        if (descriptionText.isEmpty()) {
-            descriptionText = notification.optJSONObject("metadata")?.optString("comment", "") ?: ""
+        if (descriptionText.isBlank() || descriptionText == "null") {
+            descriptionText = notification.optJSONObject("metadata")
+            ?.optString("comment", "")
+            ?.takeIf { it.isNotBlank() && it != "null" }
+            ?: ""
         }
         val hasDescription = descriptionText.isNotEmpty()
 

--- a/assets/android/MessagingService.kt
+++ b/assets/android/MessagingService.kt
@@ -160,7 +160,10 @@ class MessagingService : FirebaseMessagingService(), OnInitListener {
         val bitcoinDisplayMode = getBitcoinDisplayModeFromPreferences(this)
         val formattedAmount = if (bitcoinDisplayMode == "bip177") "₿ $amount" else "$amount sats"
 
-        val descriptionText = notification.optString("description", "")
+        var descriptionText = notification.optString("description", "")
+        if (descriptionText.isEmpty()) {
+            descriptionText = notification.optJSONObject("metadata")?.optString("comment", "") ?: ""
+        }
         val hasDescription = descriptionText.isNotEmpty()
 
         val action = when (notificationType) {

--- a/assets/android/MessagingService.kt
+++ b/assets/android/MessagingService.kt
@@ -160,13 +160,13 @@ class MessagingService : FirebaseMessagingService(), OnInitListener {
         val bitcoinDisplayMode = getBitcoinDisplayModeFromPreferences(this)
         val formattedAmount = if (bitcoinDisplayMode == "bip177") "₿ $amount" else "$amount sats"
 
-        var descriptionText = notification.optString("description", "")
-        if (descriptionText.isBlank() || descriptionText == "null") {
-            descriptionText = notification.optJSONObject("metadata")
-            ?.optString("comment", "")
-            ?.takeIf { it.isNotBlank() && it != "null" }
-            ?: ""
-        }
+        val description = notification.optString("description", "")
+            .takeIf { it != "null" }.orEmpty()
+        val metadata = notification.optJSONObject("metadata")
+        val comment = metadata?.optString("comment", "")
+            .takeIf { it != "null" }.orEmpty()
+
+        val descriptionText = description.ifEmpty { comment }
         val hasDescription = descriptionText.isNotEmpty()
 
         val action = when (notificationType) {

--- a/assets/ios/NotificationService.m
+++ b/assets/ios/NotificationService.m
@@ -149,6 +149,12 @@
     NSString *formattedAmount = isBip177 ? [NSString stringWithFormat:@"₿ %.0f", amountInSats] : [NSString stringWithFormat:@"%.0f sats", amountInSats];
 
     NSString *descriptionText = notificationDict[@"description"];
+    if (![descriptionText isKindOfClass:[NSString class]] || descriptionText.length == 0) {
+        NSDictionary *metadata = notificationDict[@"metadata"];
+        if ([metadata isKindOfClass:[NSDictionary class]]) {
+            descriptionText = metadata[@"comment"];
+        }
+    }
     BOOL hasDescription       = [descriptionText isKindOfClass:[NSString class]] && descriptionText.length > 0;
 
     NSString *notificationTitle = [notificationType isEqualToString:@"hold_invoice_accepted"]


### PR DESCRIPTION
# Description

This PR closes issue #424 by adding a fallback to `metadata.comment` when the invoice `description` (memo) is empty in push notifications.

## Changes

### 🤖 Android
- Updated [assets/android/MessagingService.kt](cci:7://file:///c:/Users/gjha6/OneDrive/Desktop/alby%202.0/go/assets/android/MessagingService.kt:0:0-0:0) to extract and use `comment` from the `metadata` object if the primary `description` field is empty.
- Uses safe JSON parsing (`optJSONObject`) to ensure stability.

### 🍎 iOS
- Updated [assets/ios/NotificationService.m](cci:7://file:///c:/Users/gjha6/OneDrive/Desktop/alby%202.0/go/assets/ios/NotificationService.m:0:0-0:0) to check `notificationDict[@"metadata"][@"comment"]` if `descriptionText` is missing.
- Includes type checks (`isKindOfClass:[NSDictionary class]`) to prevent crashes with unexpected payloads.

## Rationale
Currently, push notifications for payments (sent/received/held) only display the amount if the invoice memo is empty, even if a payment comment exists. This change ensures that relevant context provided in the comment is visible to the user immediately. This behavior now matches the existing logic in the app's internal transaction history list ([TransactionItem.tsx](cci:7://file:///c:/Users/gjha6/OneDrive/Desktop/alby%202.0/go/components/TransactionItem.tsx:0:0-0:0)).

## Verification
- [x] Verified logic priorities: `description` -> `metadata.comment` -> [(none)](cci:2://file:///c:/Users/gjha6/OneDrive/Desktop/alby%202.0/go/components/TransactionItem.tsx:14:0-16:2).
- [x] Verified cross-platform parity (Android & iOS).
- [x] Verified null-safety for cases where `metadata` is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now use a fallback description sourced from metadata when the primary description is missing, empty, or invalid. This ensures notification text consistently displays relevant content on both Android and iOS.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->