### PR TITLE
fix: bip21 lightning param parsing without address

### DIFF
--- a/lib/initiatePaymentFlow.ts
+++ b/lib/initiatePaymentFlow.ts
@@ -15,9 +15,9 @@ export async function initiatePaymentFlow(
 
   try {
     if (text.startsWith("bitcoin:")) {
-      const universalUrl = text.replace("bitcoin:", "http://");
-      const url = new URL(universalUrl);
-      const lightningParam = url.searchParams.get("lightning");
+      const bip21 = text.slice("bitcoin:".length);
+      const query = bip21.includes("?") ? bip21.split("?")[1] : "";
+      const lightningParam = new URLSearchParams(query).get("lightning");
       if (!lightningParam) {
         throw new Error("No lightning param found in bitcoin payment link");
       }


### PR DESCRIPTION
Fixes #437

Signet invoices actually work fine, the problem was with scanning a bip21 link without an address/host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Bitcoin payment links to correctly extract Lightning payment parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->